### PR TITLE
Fix undefined blog navigation URLs

### DIFF
--- a/website/src/components/navigation/DesktopNavigation.astro
+++ b/website/src/components/navigation/DesktopNavigation.astro
@@ -33,7 +33,7 @@ const recentVideos = videos.slice(0, 3);
       {recentBlogPosts.map((post) => (
         <article class="border-b border-gray-700 pb-3">
           <h4 class="font-medium text-gray-100 mb-1">
-            <a href={`/blog/${post.slug}`} class="hover:text-accent transition-colors">{post.data.title}</a>
+            <a href={`/blog/${post.id}/`} class="hover:text-accent transition-colors">{post.data.title}</a>
           </h4>
           <p class="text-sm text-gray-300 line-clamp-2 mb-1">
             {post.data.description || ''}

--- a/website/src/components/navigation/MobileNavigation.astro
+++ b/website/src/components/navigation/MobileNavigation.astro
@@ -48,7 +48,7 @@ const recentVideos = videos.slice(0, 3);
         {recentBlogPosts.map((post) => (
           <article>
             <h4 class="font-medium text-gray-100 mb-2">
-              <a href={`/blog/${post.slug}`} class="hover:text-accent transition-colors text-lg">{post.data.title}</a>
+              <a href={`/blog/${post.id}/`} class="hover:text-accent transition-colors text-lg">{post.data.title}</a>
             </h4>
             <p class="text-sm text-gray-300 mb-2">
               {post.data.description || ''}


### PR DESCRIPTION
## Summary
- use Astro collection entry IDs for desktop recent-post links
- use Astro collection entry IDs for mobile recent-post links
- keep generated URLs consistent with the blog index and static route

## Verification
- npm run build
- confirmed generated output contains no /blog/undefined links